### PR TITLE
Fix package installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf update -y && \
 
 # Add renovate user and switch to it
 RUN useradd -lms /bin/bash -u 1001 renovate
+RUN chmod -R 755 /home/renovate
 
 WORKDIR /home/renovate
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ WORKDIR /home/renovate/rpm-lockfile-prototype
 # We must pass --no-dependencies, otherwise it would try to
 # fetch dnf from PyPI, which is just a dummy package
 RUN git clone --depth=1 --branch v0.1.0-alpha.7 https://github.com/konflux-ci/rpm-lockfile-prototype.git .
-RUN pip3 install --user jsonschema PyYaml productmd requests && pip3 install --user --no-dependencies . && pip3 cache purge
+USER root
+RUN pip3 install jsonschema PyYaml productmd requests && pip3 install --no-dependencies . && pip3 cache purge
+USER 1001
 
 WORKDIR /workspace


### PR DESCRIPTION
1. Clean up caches after installing packages
2. Ensure proper permission for renovate home
3. Install rpm-lockfile-prototype globally