### PR TITLE
Adjust memory for clair scan task

### DIFF
--- a/.tekton/mintmaker-renovate-image-pull-request.yaml
+++ b/.tekton/mintmaker-renovate-image-pull-request.yaml
@@ -318,6 +318,13 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      resources:
+        limits:
+          cpu: "2"
+          memory: 4Gi
+        requests:
+          cpu: 3m
+          memory: 1Gi
       when:
       - input: $(params.skip-checks)
         operator: in

--- a/.tekton/mintmaker-renovate-image-push.yaml
+++ b/.tekton/mintmaker-renovate-image-push.yaml
@@ -315,6 +315,13 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      resources:
+        limits:
+          cpu: "2"
+          memory: 4Gi
+        requests:
+          cpu: 3m
+          memory: 1Gi
       when:
       - input: $(params.skip-checks)
         operator: in


### PR DESCRIPTION
The renoave image is large, clair scan requires much more memory to process the image, otherwise the task will run into OOMKilled error.