### PR TITLE
Remove clair-scan from tekton tasks

### DIFF
--- a/.tekton/mintmaker-renovate-image-pull-request.yaml
+++ b/.tekton/mintmaker-renovate-image-pull-request.yaml
@@ -301,28 +301,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: clair-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clair-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:eed371ce8d1473e31a0befaa60134dedce47debe9527df0932f7fdea6a0c73b9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: ecosystem-cert-preflight-checks
       params:
       - name: image-url

--- a/.tekton/mintmaker-renovate-image-push.yaml
+++ b/.tekton/mintmaker-renovate-image-push.yaml
@@ -298,28 +298,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: clair-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: clair-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:eed371ce8d1473e31a0befaa60134dedce47debe9527df0932f7fdea6a0c73b9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: ecosystem-cert-preflight-checks
       params:
       - name: image-url


### PR DESCRIPTION
The renoave image is large, clair scan requires more memory than the allocated sizes to process this image:
```
    resources:
      limits:
        memory: 2Gi
      requests:
        memory: "89478485"
```
before we figure out a way to adjust the memory or optimize the image size, we have to remove clair scan from the tekton tasks.