### PR TITLE
Update rpm lockfile script to the newer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ WORKDIR /home/renovate/rpm-lockfile-prototype
 # Clone and install the rpm-lockfile-prototype
 # We must pass --no-dependencies, otherwise it would try to
 # fetch dnf from PyPI, which is just a dummy package
-RUN git clone --depth=1 --branch v0.1.0-alpha.7 https://github.com/konflux-ci/rpm-lockfile-prototype.git .
+RUN git clone --depth=1 --branch v0.2.0 https://github.com/konflux-ci/rpm-lockfile-prototype.git .
 USER root
 RUN pip3 install jsonschema PyYaml productmd requests && pip3 install --no-dependencies . && pip3 cache purge
 USER 1001


### PR DESCRIPTION
Mintmaker doesn't detect rpm lockfile changes when image tag and digest are both provided. This is due to some skopeo known issue. This was resolved in the rpm lockfile new release. Let's move to that version.