### PR TITLE
Increase PipelineRun timeout

### DIFF
--- a/.tekton/mintmaker-renovate-image-pull-request.yaml
+++ b/.tekton/mintmaker-renovate-image-pull-request.yaml
@@ -17,6 +17,8 @@ metadata:
   name: mintmaker-renovate-image-on-pull-request
   namespace: konflux-mintmaker-tenant
 spec:
+  timeouts:
+    pipeline: "1h30m0s"
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/mintmaker-renovate-image-push.yaml
+++ b/.tekton/mintmaker-renovate-image-push.yaml
@@ -16,6 +16,8 @@ metadata:
   name: mintmaker-renovate-image-on-push
   namespace: konflux-mintmaker-tenant
 spec:
+  timeouts:
+    pipeline: "1h30m0s"
   params:
   - name: git-url
     value: '{{source_url}}'


### PR DESCRIPTION
The container build task in the PipelineRuns can take a long time to finish. The default 1h timeout is insufficient for running the remaining tasks. Updated the timeout to 1h30m to ensure successful completion.