### PR TITLE
Update to rpm-lockfile-prototype v0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ WORKDIR /home/renovate/rpm-lockfile-prototype
 # Clone and install the rpm-lockfile-prototype
 # We must pass --no-dependencies, otherwise it would try to
 # fetch dnf from PyPI, which is just a dummy package
-RUN git clone --depth=1 --branch v0.6.1 https://github.com/konflux-ci/rpm-lockfile-prototype.git .
+RUN git clone --depth=1 --branch v0.7.0 https://github.com/konflux-ci/rpm-lockfile-prototype.git .
 USER root
 RUN pip3 install jsonschema PyYaml productmd requests && pip3 install --no-dependencies . && pip3 cache purge
 USER 1001


### PR DESCRIPTION
This version contains https://github.com/konflux-ci/rpm-lockfile-prototype/pull/32 which is needed for CWFHEALTH-3245