### PR TITLE
Increase the timeouts for the pipeline and the build-container task

### DIFF
--- a/.tekton/mintmaker-renovate-image-pull-request.yaml
+++ b/.tekton/mintmaker-renovate-image-pull-request.yaml
@@ -17,7 +17,7 @@ metadata:
   namespace: konflux-mintmaker-tenant
 spec:
   timeouts:
-    pipeline: "1h30m0s"
+    pipeline: "2h30m"
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -229,6 +229,7 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
+      timeout: "2h"
       taskRef:
         params:
         - name: name

--- a/.tekton/mintmaker-renovate-image-push.yaml
+++ b/.tekton/mintmaker-renovate-image-push.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: konflux-mintmaker-tenant
 spec:
   timeouts:
-    pipeline: "1h30m0s"
+    pipeline: "2h30m"
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -226,6 +226,7 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
+      timeout: "2h"
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
TaskRun has a default timeout of 1 hour. Occasionally, the build-container task may fail due to this timeout, especially if the COMMIT/push process takes a long time.