### PR TITLE
Install openssl for hermit manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN microdnf update -y && \
     microdnf module enable -y nodejs:20/common && \
     microdnf install -y \
         git \
+        openssl \
         python3.12-pip \
         python3.12 \
         python3.11 \


### PR DESCRIPTION
Update image to work with all managers from the `no category` category https://docs.renovatebot.com/modules/manager/ .