### PR TITLE
Update base Renovate to 38.55.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN pipx install --python python3.12 poetry pdm pipenv hashin && rm -fr ~/.cache
 WORKDIR /home/renovate/renovate
 
 # Clone Renovate from specific ref (that includes the RPM lockfile support)
-RUN git clone --depth=1 --branch rpm-lockfiles https://github.com/redhat-exd-rebuilds/renovate.git .
+RUN git clone --depth=1 --branch rpm-lockfiles-new https://github.com/redhat-exd-rebuilds/renovate.git .
 
 # Replace package.json version for this build
 RUN sed -i "s/0.0.0-semantic-release/${RENOVATE_VERSION}/g" package.json


### PR DESCRIPTION
Rebased on the upstream Renovate project on the 38.55.2 tag. Also changed the version suffix from `-custom` to `-rpm` to better reflect why it's there. And this image builds from the branch `rpm-lockfiles-new` so we have a fallback in case something doesn't work (but it appears everything is ok).

Edit: this will also include the latest commit in the `rpm` manager, where the `-f Dockerfile` or `-f Containerfile` is no longer specified: https://github.com/redhat-exd-rebuilds/renovate/commit/193e711c44397c23c7931963e7d3e2c707c3d2bf