### PR TITLE
Install dependencies for pep621 python manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN npm install pnpm@9.2.0 && npm cache clean --force
 
 # Use virtualenv isolation to avoid dependency issues with other global packages
 RUN pip3.12 install --user pipx && pip3.12 cache purge
-RUN pipx install --python python3.12 poetry pdm pipenv hashin && rm -fr ~/.cache/pipx && pip3.12 cache purge
+RUN pipx install --python python3.12 poetry pdm pipenv hashin uv hatch && rm -fr ~/.cache/pipx && pip3.12 cache purge
 
 WORKDIR /home/renovate/renovate
 


### PR DESCRIPTION
This commit enables `uv` and `hatch`, which are used by the `pep621` manager in renovate.
This was a suggestion in https://github.com/konflux-ci/mintmaker/pull/92.