### PR TITLE
install pip-tools for pip-compile manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN npm install pnpm@9.2.0 && npm cache clean --force
 
 # Use virtualenv isolation to avoid dependency issues with other global packages
 RUN pip3.12 install --user pipx && pip3.12 cache purge
-RUN pipx install --python python3.12 poetry pdm pipenv hashin uv hatch && rm -fr ~/.cache/pipx && pip3.12 cache purge
+RUN pipx install --python python3.12 poetry pdm pipenv hashin uv hatch pip-tools && rm -fr ~/.cache/pipx && pip3.12 cache purge
 
 WORKDIR /home/renovate/renovate
 


### PR DESCRIPTION
pip-tools provides `pip-compile` cli, required by `pip-compile` manager enabled in https://github.com/konflux-ci/mintmaker/pull/92/files