### PR TITLE
Override ubi9's gotoolchain from local to auto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.13.1
 # specified in Renovate's package.json
 ARG NODEJS_VERSION=20.17.0
 
+# Support multiple Go versions
+ENV GOTOOLCHAIN=auto
+
 # Using OpenSSL store allows for external modifications of the store. It is needed for the internal Red Hat cert.
 ENV NODE_OPTIONS=--use-openssl-ca
 


### PR DESCRIPTION
This change allows Renovate to _renovate_ different versions of Go. There was also a suggestion to predownload different toolchains, however when i tested this agains dependency from go1.21 and go1.23 it did not redownload anything, can I skip it?