### PR TITLE
Update to rpm-lockfile-prototype v0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG RENOVATE_VERSION=38.136.0-rpm
 
 # Version for the rpm-lockfile-prototype executable from
 # https://github.com/konflux-ci/rpm-lockfile-prototype/tags
-ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.9.0
+ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.10.0
 
 # NodeJS version used for Renovate, has to satisfy the version
 # specified in Renovate's package.json


### PR DESCRIPTION
This version includes caching of rpmdb