### PR TITLE
Update Renovate version label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL description="Mintmaker - Renovate custom image" \
 
 # The version number is from upstream Renovate, while the `-rpm` suffix
 # is to differentiate the rpm lockfile enabled fork
-ARG RENOVATE_VERSION=38.55.2-rpm
+ARG RENOVATE_VERSION=38.132.0-rpm
 
 # Version for the rpm-lockfile-prototype executable from
 # https://github.com/konflux-ci/rpm-lockfile-prototype/tags


### PR DESCRIPTION
I recently rebased the `repm-lockfile-new` branch in our fork of Renovate on top of the `38.132.0` tag. In other words, we are ready to build version 38.132.0-rpm.

#### Testing remarks

I built this image manually and made manual tests in a few repositories. So far, everything seems to work fine, we do not need a new node version for what it seems.
I'll watch the stage runs after this change is merged.