### PR TITLE
Set up Renovate to update rpm-lockfile-prototype version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,19 @@
     "automergeSchedule": [
       "after 12am and before 12pm on sunday"
     ]
-  }
+  },
+  "customManagers": [
+    {
+        "fileMatch": [
+            "^Dockerfile$"
+        ],
+        "customType": "regex",
+        "datasourceTemplate": "github-tags",
+        "depNameTemplate": "konflux-ci/rpm-lockfile-prototype",
+        "matchStrings": [
+            "ARG RPM_LOCKFILE_PROTOTYPE_VERSION=(?<currentValue>[\\d\\.]+)"
+        ],
+        "versioningTemplate": "semver"
+    }
+  ]
 }


### PR DESCRIPTION
Tested, proposes diffs as
```diff
-ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.10.0
+ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.11.0
```