### PR TITLE
Update tekton manager schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,10 +3,7 @@
     "enabled": true,
     "automergeType": "pr",
     "automerge": true,
-    "platformAutomerge": true,
-    "automergeSchedule": [
-      "after 12am and before 12pm on sunday"
-    ]
+    "platformAutomerge": true
   },
   "customManagers": [
     {


### PR DESCRIPTION
The tekton manager only runs on Saturdays in latest global schedules, so there's no need to specify a custom schedule. Defining a schedule outside the global schedule window could also prevent pull requests from being created or merged.