### PR TITLE
Fix pip-compile manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN npm install pnpm@9.2.0 && npm cache clean --force
 
 # Use virtualenv isolation to avoid dependency issues with other global packages
 RUN pip3.12 install --user pipx && pip3.12 cache purge
-RUN pipx install --python python3.12 poetry pdm pipenv hashin uv hatch pip-tools && rm -fr ~/.cache/pipx && pip3.12 cache purge
+RUN pipx install --python python3.12 poetry pdm pipenv hashin uv hatch && rm -fr ~/.cache/pipx && pip3.12 cache purge
 
 # Install pyenv
 RUN curl https://pyenv.run | sh


### PR DESCRIPTION
Turns out to enable pip-compile with different versions of Python, you should let renovate install it on its own. (:

This PR fixes a bug which forced all pip-compile updates with Python 3.12, even when project was using an older version. By predownloading several versions of pip-tools, Renovate will automatically use the newest one (python3.12 in this case), ignoring the repository preset.

Closes [CWFHEALTH-3879](https://issues.redhat.com/browse/CWFHEALTH-3879).