### PR TITLE
Add python 3.13 and 3.10 via pyenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ ENV NODE_OPTIONS=--use-openssl-ca
 
 ENV LANG=C.UTF-8
 
+# PYENV_ROOT is also set in ~/.profile, but the file isn't always read
+ENV PYENV_ROOT="/home/renovate/.pyenv"
+
 RUN microdnf update -y && \
     microdnf install -y \
         git \
@@ -92,6 +95,13 @@ RUN curl https://pyenv.run | sh
 RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile && \
     echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.profile && \
     echo 'eval "$(pyenv init -)"' >> ~/.profile
+
+# Install additional Python versions
+RUN $PYENV_ROOT/plugins/python-build/bin/python-build $(pyenv latest -f -k 3.10) $HOME/python3.10
+ENV PATH="${PATH}:/home/renovate/python3.10/bin"
+
+RUN $PYENV_ROOT/plugins/python-build/bin/python-build $(pyenv latest -f -k 3.13) $HOME/python3.13
+ENV PATH="${PATH}:/home/renovate/python3.13/bin"
 
 WORKDIR /home/renovate/renovate
 


### PR DESCRIPTION
This uses `pyenv`'s internals to do what `pyenv install` would normally do, but that way we wouldn't be able to specify the install root (or prefix).

- `pyenv latest -f -k 3.13` will check which minor version is the newest for 3.13 (currently 3.13.1)
- The Python is installed into `~/pythonX.YY` so that we can easily add that into `$PATH`. We cannot dynamically modify `$PATH`, so we need to make a workaround like this.
- The `python-build` is a `pyenv` plugin that's part of the installation, but we need to invoke it directly to be able to change the install root

I tested this on a reported repo with poetry that wants to use 3.13 and Renovate can update the lock file correctly after this change.