### PR TITLE
Install yq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN microdnf update -y && \
 
 RUN curl -L -o /tmp/tkn.tar.gz https://github.com/tektoncd/cli/releases/download/v0.38.1/tkn_0.38.1_Linux_x86_64.tar.gz && tar xvzf /tmp/tkn.tar.gz -C /usr/bin/ tkn && rm -f /tmp/tkn.tar.gz
 
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
+
 # Install nodejs
 RUN curl -o node-v${NODEJS_VERSION}-linux-x64.tar.xz https://nodejs.org/dist/v${NODEJS_VERSION}/node-v${NODEJS_VERSION}-linux-x64.tar.xz
 RUN tar xf node-v${NODEJS_VERSION}-linux-x64.tar.xz && \


### PR DESCRIPTION
STONEBLD-2824

The pipeline-migration-tool requires yq to execute task migrations.