### PR TITLE
Bump renovate version to 39.158.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL description="Mintmaker - Renovate custom image" \
 
 # The version number is from upstream Renovate, while the `-rpm` suffix
 # is to differentiate the rpm lockfile enabled fork
-ARG RENOVATE_VERSION=38.132.0-rpm
+ARG RENOVATE_VERSION=39.158.0-rpm
 
 # Version for the rpm-lockfile-prototype executable from
 # https://github.com/konflux-ci/rpm-lockfile-prototype/tags


### PR DESCRIPTION
Reflects renovate version update. I synced the fork at https://github.com/redhat-exd-rebuilds/renovate/tree/rpm-lockfiles-new and tested the image locally. 