### PR TITLE
Switch to a branch containing contianer CVE updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ ENV PATH="${PATH}:/home/renovate/python3.13/bin"
 WORKDIR /home/renovate/renovate
 
 # Clone Renovate from specific ref (that includes the RPM lockfile support)
-RUN git clone --depth=1 --branch rpm-lockfiles-new https://github.com/redhat-exd-rebuilds/renovate.git .
+RUN git clone --depth=1 --branch develop https://github.com/redhat-exd-rebuilds/renovate.git .
 
 # Replace package.json version for this build
 RUN sed -i "s/0.0.0-semantic-release/${RENOVATE_VERSION}/g" package.json


### PR DESCRIPTION
The new branch is a combination of rpm-lockfiles-new and container-cve branches.