### PR TITLE
Add krb5-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN microdnf update -y && \
         readline \
         sqlite \
         sqlite-devel \
-        libpq-devel && \
+        libpq-devel \
+        krb5-devel && \
     microdnf clean all
 
 RUN curl -L -o /tmp/tkn.tar.gz https://github.com/tektoncd/cli/releases/download/v0.38.1/tkn_0.38.1_Linux_x86_64.tar.gz && tar xvzf /tmp/tkn.tar.gz -C /usr/bin/ tkn && rm -f /tmp/tkn.tar.gz


### PR DESCRIPTION
For projects that require building Python wheels like pykerberos