### PR TITLE
Add jsonnet-bundler binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN $PYENV_ROOT/plugins/python-build/bin/python-build $(pyenv latest -f -k 3.13)
 ENV PATH="${PATH}:/home/renovate/python3.13/bin"
 
 # Install jsonnet-bundler
-RUN go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+RUN go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest && go clean -cache -modcache
 
 WORKDIR /home/renovate/renovate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,9 @@ ENV PATH="${PATH}:/home/renovate/python3.10/bin"
 RUN $PYENV_ROOT/plugins/python-build/bin/python-build $(pyenv latest -f -k 3.13) $HOME/python3.13
 ENV PATH="${PATH}:/home/renovate/python3.13/bin"
 
+# Install jsonnet-bundler
+RUN go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+
 WORKDIR /home/renovate/renovate
 
 # Clone Renovate from the fork and checkout the specific commit that includes custom


### PR DESCRIPTION
This is required to run `jb update` which currently fails for a bunch of user repos.