### PR TITLE
Install the subscription-manager-rhsm-certificates rpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV PYENV_ROOT="/home/renovate/.pyenv"
 
 RUN microdnf update -y && \
     microdnf install -y \
+        subscription-manager-rhsm-certificates \
         git \
         openssl \
         python3.12-pip \


### PR DESCRIPTION
The subscription-manager-rhsm-certificates rpm provides the CA certificate /etc/rhsm/ca/redhat-uep.pem for SSL verification. This is required by default for rpm lockfile management when subscription is used.

JIRA: CWFHEALTH-4189