### PR TITLE
Use pipx to install rpm-lockfile-prototype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,14 +197,8 @@ RUN sed -i "s/0.0.0-semantic-release/${RENOVATE_VERSION}/g" package.json
 # Install project dependencies, build and install Renovate
 RUN pnpm install && pnpm build && npm install --prefix /home/renovate . && pnpm store prune && npm cache clean --force
 
-WORKDIR /home/renovate/rpm-lockfile-prototype
-
-# Clone and install the rpm-lockfile-prototype
-# We must pass --no-dependencies, otherwise it would try to
-# fetch dnf from PyPI, which is just a dummy package
-RUN git clone --depth=1 --branch v${RPM_LOCKFILE_PROTOTYPE_VERSION} https://github.com/konflux-ci/rpm-lockfile-prototype.git .
-USER root
-RUN pip3 install jsonschema PyYaml productmd requests && pip3 install --no-dependencies . && pip3 cache purge
-USER 1001
+# Run pipx install with the --system-site-packages so rpm-lockfile-prototype can use the system's python3-dnf package
+RUN pipx install --python python3.12 git+https://github.com/konflux-ci/rpm-lockfile-prototype.git@v${RPM_LOCKFILE_PROTOTYPE_VERSION} --system-site-packages && \
+    rm -fr ~/.cache/pipx && pip3.12 cache purge
 
 WORKDIR /workspace


### PR DESCRIPTION
The `--system-site-packages` flag ensures that `rpm-lockfile-prototype` can use `python3-dnf` from `/usr/lib/python3.xx`