### PR TITLE
Bump renovate to use the new RPM workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY LICENSE /licenses/LICENSE
 ARG RENOVATE_VERSION=41.90.1-rpm
 
 # Specific git commit hash from the redhat-exd-rebuilds/renovate fork
-ARG RENOVATE_REVISION=b7030781a08741ddeafae1f1f5114059945c6ce4
+ARG RENOVATE_REVISION=00a85615cc1dbf20d535a47d857516e08a726e99
 
 # Version for the rpm-lockfile-prototype executable from
 # https://github.com/konflux-ci/rpm-lockfile-prototype/tags


### PR DESCRIPTION
This should be deployed together with https://github.com/konflux-ci/mintmaker/pull/355