### PR TITLE
Bump renovate to remove old RPM code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY LICENSE /licenses/LICENSE
 ARG RENOVATE_VERSION=41.90.1-rpm
 
 # Specific git commit hash from the redhat-exd-rebuilds/renovate fork
-ARG RENOVATE_REVISION=00a85615cc1dbf20d535a47d857516e08a726e99
+ARG RENOVATE_REVISION=84191509a215d6f9e4780523571bd0aa7fcd90a9
 
 # Version for the rpm-lockfile-prototype executable from
 # https://github.com/konflux-ci/rpm-lockfile-prototype/tags


### PR DESCRIPTION
Before merging this, we should confirm that the new RPM workflow has no issues in prod