### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -238,7 +238,6 @@ RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.profile && \
 COPY install-python.sh /home/renovate/install-python.sh
 
 # Download prebuilt CPython
-RUN ./install-python.sh 3.9
 RUN ./install-python.sh 3.10
 RUN ./install-python.sh 3.11
 RUN ./install-python.sh 3.13
@@ -253,7 +252,7 @@ ENV SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
 ENV SSL_CERT_DIR=/etc/pki/tls/certs
 
 # Update paths
-ENV PATH="${PATH}:/home/renovate/python3.9/bin:/home/renovate/python3.10/bin:/home/renovate/python3.11/bin:/home/renovate/python3.13/bin:/home/renovate/python3.14/bin"
+ENV PATH="${PATH}:/home/renovate/python3.10/bin:/home/renovate/python3.11/bin:/home/renovate/python3.13/bin:/home/renovate/python3.14/bin"
 
 # Install jsonnet-bundler
 RUN go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest && go clean -cache -modcache

--- a/install-python.sh
+++ b/install-python.sh
@@ -12,12 +12,7 @@ fi
 # Get the latest release tag (in format YYYYMMDD) and use that to filter all release assets
 # to find one matching cpython-{version}-{arch}-{configuration}.tar.gz, since the patch version
 # is not known to this script, i.e. we request "3.13", but we don't know that "3.13.7" is the latest
-if [ "$PYTHON_VERSION" = "3.9" ]; then
-    RELEASE_TAG="20251028"
-else
-    RELEASE_TAG=$(curl -s -L -H "Accept: application/json" https://github.com/astral-sh/python-build-standalone/releases/latest | jq -r .tag_name)
-fi
-
+RELEASE_TAG=$(curl -s -L -H "Accept: application/json" https://github.com/astral-sh/python-build-standalone/releases/latest | jq -r .tag_name)
 DOWNLOAD_URL=$(curl -s -L -H "Accept: application/json" "https://api.github.com/repos/astral-sh/python-build-standalone/releases/tags/$RELEASE_TAG" | jq ".assets.[]|select(.name | startswith(\"cpython-$PYTHON_VERSION\"))|select(.name | endswith(\"$ARCH-$CONFIGURATION.tar.gz\"))" | jq -r .browser_download_url)
 
 # Download the archive and extract into ~/python{version}


### PR DESCRIPTION
Python 3.9 has been EOL since 2025-10-31, `pip` dropped support on 2026-04-26.