### PR TITLE
chore(deps): update pnpm to 10.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ARG YQ_VERSION=4.53.2
 # specified in Renovate's package.json
 ARG NODEJS_VERSION=24.11.0
 
-ARG PNPM_VERSION=10.23.0
+ARG PNPM_VERSION=10.28.0
 
 # Do not remove the following line, renovate uses it to propose version updates
 # renovate: datasource=npm depName=yarn


### PR DESCRIPTION
chore(deps): update pnpm to 10.28.0

We use `10.28.0` in our project and I noticed that this was a few
versions behind.

Kindly requesting that we update this :)
