### PR TITLE
Update pnpm to 10.33.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ARG YQ_VERSION=4.53.2
 # specified in Renovate's package.json
 ARG NODEJS_VERSION=24.11.0
 
-ARG PNPM_VERSION=10.23.0
+ARG PNPM_VERSION=10.33.4
 
 # Do not remove the following line, renovate uses it to propose version updates
 # renovate: datasource=npm depName=yarn


### PR DESCRIPTION
This is the last version before v11, our current Renovate version 42.99.0 requires `^10.0.0` to build. I verified MintMaker still builds with this version and ran a few E2E tests, everything seems ok.