### PR TITLE
Downgrade uv due to cache directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ ARG HASHIN_VERSION=1.0.5
 
 # Do not remove the following line, renovate uses it to propose version updates
 # renovate: datasource=pypi depName=uv
-ARG UV_VERSION=0.11.14
+ARG UV_VERSION=0.11.8
 
 # Do not remove the following line, renovate uses it to propose version updates
 # renovate: datasource=pypi depName=hatch


### PR DESCRIPTION
New uv versions slightly reworked how the cache directory structure works, so newer versions will attempt to create subdirs within ~/.cache/uv but because OpenShift randomizes UIDs, the 0775 is not enough, as we rely on GID=0 for writes. However, that only applies to the dirs we create during docker build, whereas newly created subdirs at runtime are created with 0755 due to the default umask being 0022, which prevents any new subdir to be writable by the uv process.