### PR TITLE
chore: add CI lint gate for Dockerfile, shell, and docs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,6 +43,16 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
       ]
+    },
+    {
+      "managerFilePatterns": [
+        "/^\\.github/workflows\\/.*\\.ya?ml$/"
+      ],
+      "customType": "regex",
+      "description": "Update tool versions in GitHub Actions workflows",
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s+ACTIONLINT_VERSION: (?<currentValue>\\S+)"
+      ]
     }
   ]
 }

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -20,6 +20,7 @@ name: fullsend
 permissions:
   actions: write
   id-token: write
+  checks: read
   contents: read
   pull-requests: read
 
@@ -34,13 +35,36 @@ on:
     types: [submitted]
 
 jobs:
+  wait-for-lint:
+    if: >-
+      github.event_name == 'pull_request_target'
+      && contains(fromJSON('["opened","synchronize","ready_for_review"]'), github.event.action)
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      pull-requests: read
+    steps:
+      - name: Wait for Lint job to finish
+        uses: lewagon/wait-on-check-action@96d9100b431964d10e0136aff8b9ccb92470505e # v1.8.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: "Lint Dockerfile, Shell scripts, and Markdown"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          checks-discovery-timeout: 600
+
   dispatch:
+    needs: wait-for-lint
     concurrency:
       group: fullsend-dispatch-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     if: >-
-      github.event_name != 'issue_comment'
-      || github.event.comment.user.type != 'Bot'
+      always()
+      && (needs.wait-for-lint.result == 'success' || needs.wait-for-lint.result == 'skipped')
+      && (
+        github.event_name != 'issue_comment'
+        || github.event.comment.user.type != 'Bot'
+      )
     uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@ec21706cccc58d01588ecd842464a5afcc375ba1 # main
     with:
       event_action: ${{ github.event.action }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,50 @@
+name: Code quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint Dockerfile, Shell scripts, and Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Hadolint
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: Dockerfile
+          config: .hadolint.yaml
+          failure-threshold: warning
+
+      - name: Shellcheck
+        run: shellcheck -x install-python.sh
+
+      - name: Markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19
+        with:
+          config: .markdownlint.json
+          globs: |
+            README.md
+            AGENTS.md
+
+      - name: Actionlint
+        env:
+          # renovate: datasource=github-tags depName=rhysd/actionlint versioning=semver
+          ACTIONLINT_VERSION: 1.7.12
+        run: |
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz actionlint
+          chmod +x actionlint
+          ./actionlint -shellcheck=shellcheck .github/workflows/*.yaml

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,23 @@
+# Hadolint config for mintmaker-renovate-image.
+# Baselined rules are legacy Dockerfile patterns; see issue for cleanup backlog.
+# renovate: datasource=github-tags depName=hadolint/hadolint versioning=semver
+ignored:
+  # UBI base images use Red Hat catalog floating tags, not semver pins.
+  - DL3006
+  # microdnf install does not pin individual package versions.
+  - DL3041
+  # Intentional layer separation for cache granularity and faster rebuilds.
+  - DL3059
+  # Piped RUN steps (pyenv, rustup) do not set SHELL with pipefail.
+  - DL4006
+  # pip/pipx cache purge steps are intentional during image build.
+  - DL3042
+  # pip/pipx installs use ARG-pinned versions; hadolint cannot see substitutions.
+  - DL3013
+  # jsonnet-bundler is installed at @latest by design.
+  - DL3062
+  # Renovate build uses npm install --prefix with a local package.json.
+  - DL3016
+
+trustedRegistries:
+  - registry.access.redhat.com

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ This repository hosts the custom Renovate container image for MintMaker. It is a
 
 - **Build**: `podman build --ulimit nofile=65535:65535 . -t custom-renovate`
 - **Run**: `podman run --rm <additional args> custom-renovate renovate`
+- **Lint**: `make lint`
 
 *Note: You can replace podman with docker in the commands above depending on the available local container engine.*
+
+Lint coverage and baselined rules are documented in [README.md (Development section)](README.md#development).
 
 ## Agent Directives
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: lint
+lint:
+	hadolint --failure-threshold warning --config .hadolint.yaml Dockerfile
+	shellcheck -x install-python.sh
+	markdownlint-cli2 --config .markdownlint.json README.md AGENTS.md
+	actionlint -shellcheck=shellcheck .github/workflows/*.yaml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mintmaker-renovate-image
 
 This repo hosts the MintMaker container image.
-This container image is built and pushed [here](https://quay.io/konflux-ci/mintmaker-renovate-image) with Konflux, so it is an automatic process.
+This container image is built and pushed to [Quay](https://quay.io/konflux-ci/mintmaker-renovate-image) with Konflux, so it is an automatic process.
 
 This image is a custom [Renovate](https://docs.renovatebot.com/) image, with the addition of the `rpm` manager: that uses the [rpm-lockfile-prototype](https://github.com/konflux-ci/rpm-lockfile-prototype) to update a lockfile that tracks installed rpms.
 
@@ -10,20 +10,20 @@ Some dependencies are installed in this image in order to have the necessary dep
 ## rpm-lockfile support
 
 The main difference of this image with the upstream Renovate image is the support for the `rpm` manager. This is a custom manager.
-In order to support this, we maintain a fork of Renovate, that can be found [here](https://github.com/redhat-exd-rebuilds/renovate).
+In order to support this, we maintain a fork of Renovate [on GitHub](https://github.com/redhat-exd-rebuilds/renovate).
 
 As mentioned before, the `rpm` manager uses the [rpm-lockfile-prototype](https://github.com/konflux-ci/rpm-lockfile-prototype) to update a lockfile that tracks installed rpms.
 
-# Dockerfile design
+## Dockerfile design
 
 MintMaker's [Dockerfile](https://github.com/konflux-ci/mintmaker-renovate-image/blob/main/Dockerfile) is built from [ubi10-minimal](https://catalog.redhat.com/en/software/containers/ubi10-minimal/66f16af45db83414cddcfc99).
 
 The container image has to provide the following as a bare minimum:
 
 - `renovate` executable
-    - `node` and `npm` executables to be able to build Renovate from source
+  - `node` and `npm` executables to be able to build Renovate from source
 - `tkn` executable for running inside a Tekton pipeline
-- `$PATH` environment variable extended with directories that contain 
+- `$PATH` environment variable extended with directories that contain
   executables of different managers
 - The `renovate` user under which all processes run
 - `git` for cloning the source repositories
@@ -60,3 +60,68 @@ from each other's dependencies.
 
 Some Python based projects can require a specific Python version,
 which is why the Dockerfile adds multiple Python versions via `microdnf install`.
+
+## Development
+
+### Lint
+
+Install the linters locally, then run `make lint`. CI runs the same checks in the `lint` job.
+
+**macOS (Homebrew + npm):**
+
+```bash
+brew install hadolint shellcheck actionlint
+npm install -g markdownlint-cli2@0.17.2
+make lint
+```
+
+**Run individual checks:**
+
+```bash
+hadolint --failure-threshold warning --config .hadolint.yaml Dockerfile
+shellcheck -x install-python.sh
+markdownlint-cli2 --config .markdownlint.json README.md AGENTS.md
+actionlint -shellcheck=shellcheck .github/workflows/*.yaml
+```
+
+`--failure-threshold warning` skips hadolint *info* findings (e.g. intentional single quotes in the pyenv profile setup).
+
+### Build
+
+```bash
+podman build --ulimit nofile=65535:65535 . -t custom-renovate
+```
+
+### Lint coverage
+
+| Location                                 | Linter                                   |
+| ---------------------------------------- | ---------------------------------------- |
+| `Dockerfile` `RUN` shell                 | hadolint (+ shellcheck where applicable) |
+| `install-python.sh`                      | shellcheck                               |
+| `.github/workflows/*.yaml` inline `run:` | actionlint + shellcheck                  |
+| `README.md`, `AGENTS.md`                 | markdownlint                             |
+
+### Lint baselines
+
+Some pre-existing patterns are baselined so CI blocks only **new** violations. Config lives in `.hadolint.yaml` and `.markdownlint.json`.
+
+#### Hadolint (`.hadolint.yaml`)
+
+| Rule   | Why it is ignored                                                                          |
+| ------ | ------------------------------------------------------------------------------------------ |
+| DL3006 | Base image uses Red Hat catalog tags (`ubi10-minimal`), not semver pins                    |
+| DL3041 | `microdnf install` does not pin individual RPM package versions                            |
+| DL3059 | Many separate `RUN` instructions are intentional for Docker layer caching                  |
+| DL4006 | Piped `RUN` steps (pyenv, rustup) do not use `SHELL … pipefail`; acceptable for this image |
+| DL3042 | `pip`/`pipx` cache purge steps are deliberate during image build                           |
+| DL3013 | Python packages are pinned via `ARG` + `${…}`; hadolint cannot see those substitutions     |
+| DL3062 | `go install …@latest` for jsonnet-bundler is intentional                                   |
+| DL3016 | `npm install --prefix` uses the local Renovate `package.json`, not a bare package name     |
+
+`registry.access.redhat.com` is listed as a trusted registry.
+
+#### Markdownlint (`.markdownlint.json`)
+
+| Rule  | Why it is disabled                                       |
+| ----- | -------------------------------------------------------- |
+| MD013 | Line length — docs contain long URLs and technical prose |

--- a/install-python.sh
+++ b/install-python.sh
@@ -16,11 +16,11 @@ RELEASE_TAG=$(curl -s -L -H "Accept: application/json" https://github.com/astral
 DOWNLOAD_URL=$(curl -s -L -H "Accept: application/json" "https://api.github.com/repos/astral-sh/python-build-standalone/releases/tags/$RELEASE_TAG" | jq ".assets.[]|select(.name | startswith(\"cpython-$PYTHON_VERSION\"))|select(.name | endswith(\"$ARCH-$CONFIGURATION.tar.gz\"))" | jq -r .browser_download_url)
 
 # Download the archive and extract into ~/python{version}
-curl -s -L -o /tmp/python-$PYTHON_VERSION.tar.gz $DOWNLOAD_URL
-mkdir $HOME/python$PYTHON_VERSION
-tar xf /tmp/python-$PYTHON_VERSION.tar.gz -C $HOME/python$PYTHON_VERSION
-mv $HOME/python$PYTHON_VERSION/python/* $HOME/python$PYTHON_VERSION/
+curl -s -L -o "/tmp/python-${PYTHON_VERSION}.tar.gz" "${DOWNLOAD_URL}"
+mkdir "${HOME}/python${PYTHON_VERSION}"
+tar xf "/tmp/python-${PYTHON_VERSION}.tar.gz" -C "${HOME}/python${PYTHON_VERSION}"
+mv "${HOME}/python${PYTHON_VERSION}/python/"* "${HOME}/python${PYTHON_VERSION}/"
 
 # Clean up
-rm -r $HOME/python$PYTHON_VERSION/python
-rm /tmp/python-$PYTHON_VERSION.tar.gz
+rm -r "${HOME}/python${PYTHON_VERSION}/python"
+rm "/tmp/python-${PYTHON_VERSION}.tar.gz"


### PR DESCRIPTION
Introduce lint workflow (hadolint, shellcheck, markdownlint, actionlint) and gate fullsend dispatch on it so AI review runs only after lint passes.

Baseline justified hadolint rules for UBI/RPM/ARG-based build patterns and disable MD013 line-length in markdownlint.

Add `make lint`, document local tool install and baselines in README, and fix shellcheck quoting in install-python.sh.