### PR TITLE
fix(renovate): use maven versioning for clojure updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ ARG HELM_V3_VERSION=4.2.2
 ARG GRADLE_VERSION=9.6.1
 
 # Do not remove the following line, renovate uses it to propose version updates
-# renovate: datasource=github-tags depName=clojure/brew-install
+# renovate: datasource=github-tags depName=clojure/brew-install versioning=maven
 ARG CLOJURE_VERSION=1.12.4.1582
 
 # Do not remove the following line, renovate uses it to propose version updates


### PR DESCRIPTION
Added `versioning=maven` to the clojure/brew-install Renovate annotation. This should fix an issue where Renovate's default SemVer parser would silently skip 4-part Clojure versions because it deemed them invalid.