### PR TITLE
Bump rpm-lockfile-prototype from 0.26.0 to 0.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ARG RENOVATE_REVISION=eecc53c22df3ca68fcecc002b18162e712030baf
 # https://github.com/konflux-ci/rpm-lockfile-prototype/tags
 # Do not remove the following line, renovate uses it to propose version updates
 # renovate: datasource=github-tags depName=konflux-ci/rpm-lockfile-prototype versioning=semver
-ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.26.0
+ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.27.0
 
 # Version for the refresh-rpm-lockfiles executable from
 # https://github.com/konflux-ci/refresh-rpm-lockfiles/tags


### PR DESCRIPTION
v0.27.0 adds:
- Glob support and `enabled=0` filtering for repofiles (#162)
- `matchContextVersions` to pin packages to context image versions (#160)
- XDG_CACHE_HOME support (#165)

Changelog: https://github.com/konflux-ci/rpm-lockfile-prototype/compare/v0.26.0...v0.27.0