### PR TITLE
Enable dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "helpers:pinGitHubActionDigestsToSemver"
   ],
+  "dependencyDashboard": true,
   "tekton": {
     "enabled": true,
     "automergeType": "pr",


### PR DESCRIPTION
I'd like to enable the dashboard because it contains helpful information that might sometimes be found only in logs.