### PR TITLE
fix: drop Renovate build node_modules to clear CVE-2026-54272

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -265,7 +265,11 @@ RUN git clone --depth=1 --branch renovate-43-268-1 https://github.com/redhat-exd
 # Replace package.json version for this build
 RUN sed -i "s/0.0.0-semantic-release/${RENOVATE_VERSION}/g" package.json
 # Install project dependencies, build and install Renovate
-RUN pnpm install && pnpm build && PNPM_HOME=/home/renovate/.local pnpm add -g . && pnpm store prune && npm cache clean --force
+RUN pnpm install && pnpm build \
+    && PNPM_HOME=/home/renovate/.local pnpm add -g . \
+    && pnpm store prune \
+    && npm cache clean --force \
+    && rm -rf /home/renovate/renovate/node_modules
 
 # Run pipx install with the --system-site-packages so rpm-lockfile-prototype can use the system's python3-dnf package
 RUN pipx install --python python3.12 git+https://github.com/konflux-ci/rpm-lockfile-prototype.git@v${RPM_LOCKFILE_PROTOTYPE_VERSION} --system-site-packages && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -267,9 +267,9 @@ RUN sed -i "s/0.0.0-semantic-release/${RENOVATE_VERSION}/g" package.json
 # Install project dependencies, build and install Renovate
 RUN pnpm install && pnpm build \
     && PNPM_HOME=/home/renovate/.local pnpm add -g . \
+    && pnpm prune --prod --ignore-scripts \
     && pnpm store prune \
-    && npm cache clean --force \
-    && rm -rf /home/renovate/renovate/node_modules
+    && npm cache clean --force
 
 # Run pipx install with the --system-site-packages so rpm-lockfile-prototype can use the system's python3-dnf package
 RUN pipx install --python python3.12 git+https://github.com/konflux-ci/rpm-lockfile-prototype.git@v${RPM_LOCKFILE_PROTOTYPE_VERSION} --system-site-packages && \


### PR DESCRIPTION
Removes `/home/renovate/renovate/node_modules` after Renovate is built and installed globally (`pnpm add -g .`). This clears scanner findings for **CVE-2026-54272** (`ip-address` 10.1.1–10.2.0) without changing how Renovate is built or run. 

This dependency is part of the image only because it is needed for Renovate build - it does not need to stay there after that (it is not a runtime dep). Removing the node modules will remove this volnurability from the final image.

Jira: [KONFLUX-15268](https://redhat.atlassian.net/browse/KONFLUX-15268)

[KONFLUX-15268]: https://redhat.atlassian.net/browse/KONFLUX-15268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ