### PR TITLE
install update_artifacts_lockfile through pipx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,12 @@ ARG RPM_LOCKFILE_PROTOTYPE_VERSION=0.30.1
 # renovate: datasource=github-tags depName=konflux-ci/refresh-rpm-lockfiles versioning=semver
 ARG REFRESH_RPM_LOCKFILES_VERSION=0.1.3
 
+# Version for the update-artifacts-lockfile executable from
+# https://github.com/coreos/update-artifacts-lockfile/tags
+# Do not remove the following line, renovate uses it to propose version updates
+# renovate: datasource=github-tags depName=coreos/update-artifacts-lockfile versioning=semver
+ARG UPDATE_ARTIFACTS_LOCKFILE_VERSION=0.1.0
+
 # Version for the pipeline-migration-tool from
 # https://github.com/konflux-ci/pipeline-migration-tool/tags
 # Do not remove the following line, renovate uses it to propose version updates
@@ -276,6 +282,9 @@ RUN pipx install --python python3.12 git+https://github.com/konflux-ci/rpm-lockf
     rm -fr ~/.cache/pipx && pip3.12 cache purge
 
 RUN pipx install --python python3.12 git+https://github.com/konflux-ci/refresh-rpm-lockfiles.git@v${REFRESH_RPM_LOCKFILES_VERSION} && \
+    rm -fr ~/.cache/pipx && pip3.12 cache purge
+
+RUN pipx install --python python3.12 git+https://github.com/coreos/update-artifacts-lockfile.git@v${UPDATE_ARTIFACTS_LOCKFILE_VERSION} && \
     rm -fr ~/.cache/pipx && pip3.12 cache purge
 
 WORKDIR /workspace


### PR DESCRIPTION
Installs update_artifacts_lockfile from coreos/update-artifacts-lockfile repository, following the same pattern as `refresh-rpm-lockfiles` suggested [here](https://github.com/konflux-ci/mintmaker-renovate-image/pull/539#issuecomment-5231459025).

Depends on: konflux-ci/mintmaker#597